### PR TITLE
remove SuperLearner from Imports

### DIFF
--- a/pkg/DESCRIPTION
+++ b/pkg/DESCRIPTION
@@ -14,7 +14,6 @@ Imports:
     foreach,
     parallel,
     doParallel,
-    SuperLearner,
     calibrate,
     magrittr,
     R2HTML


### PR DESCRIPTION
This implements the required change to resolve the problem with extraneous Imports mentioned in #14 

The **SuperLearn** package is listed under `Imports` in `DESCRIPTION` but this package is not actually used in **data.adapt.multi.test**. This PR removes the **SuperLearner** package from the `Imports` tag in `DESCRIPTION`.

Running `R CMD check` on a tarball built from the source tree with this change made results in no NOTEs.